### PR TITLE
Added extension methods to send messages with System.Text.Json serialized by source generator

### DIFF
--- a/samples/RabbitMQCoreClient.ConsoleClient/Program.cs
+++ b/samples/RabbitMQCoreClient.ConsoleClient/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using RabbitMQCoreClient;
 using RabbitMQCoreClient.BatchQueueSender;
+using RabbitMQCoreClient.BatchQueueSender.DependencyInjection;
 using RabbitMQCoreClient.Configuration.DependencyInjection.Options;
 using RabbitMQCoreClient.ConsoleClient;
 using RabbitMQCoreClient.Serializers;
@@ -41,17 +42,14 @@ using IHost host = new HostBuilder()
             .AddRabbitMQCoreClientConsumer(builder.Configuration.GetSection("RabbitMQ"))
             .AddHandler<Handler>(new[] { "test_routing_key" }, new ConsumerHandlerOptions
             {
-                RetryKey = "test_routing_key_retry",
-                CustomSerializer = new SystemTextJsonMessageSerializer(x =>
-                {
-                    x.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-                    x.PropertyNameCaseInsensitive = false;
-                })
+                RetryKey = "test_routing_key_retry"
             })
             .AddHandler<Handler>(new[] { "test_routing_key_subscription" }, new ConsumerHandlerOptions
             {
                 RetryKey = "test_routing_key_retry"
             });
+
+        services.AddBatchQueueSender();
 
         // For sending and consuming messages full configuration.
         //services
@@ -69,7 +67,7 @@ var serviceProvider = host.Services;
 
 var queueService = serviceProvider.GetRequiredService<IQueueService>();
 var consumer = serviceProvider.GetRequiredService<IQueueConsumer>();
-//var batchSender = serviceProvider.GetRequiredService<IQueueEventsBufferEngine>();
+var batchSender = serviceProvider.GetRequiredService<IQueueEventsBufferEngine>();
 consumer.Start();
 
 //var body = new SimpleObj { Name = "test sending" };
@@ -93,8 +91,8 @@ consumer.Start();
 //        }
 //    }));
 CancellationTokenSource source = new CancellationTokenSource();
-await CreateSender(queueService, source.Token);
-//await CreateBatchSender(batchSender, source.Token);
+//await CreateSender(queueService, source.Token);
+await CreateBatchSender(batchSender, source.Token);
 
 //var bodyList = Enumerable.Range(1, 1).Select(x => new SimpleObj { Name = $"test sending {x}" });
 //await queueService.SendBatchAsync(bodyList, "test_routing_key", jsonSerializerSettings: new Newtonsoft.Json.JsonSerializerSettings()).AsTask();
@@ -109,7 +107,7 @@ static async Task CreateSender(IQueueService queueService, CancellationToken tok
         {
             await Task.Delay(1000, token);
             var bodyList = Enumerable.Range(1, 1).Select(x => new SimpleObj { Name = $"test sending {x}" });
-            await queueService.SendBatchAsync(bodyList, "test_routing_key");
+            await queueService.SendBatchAsync(bodyList, "test_routing_key", SimpleObjContext.Default.SimpleObj);
         }
         catch (Exception e)
         {
@@ -126,7 +124,7 @@ static async Task CreateBatchSender(IQueueEventsBufferEngine batchSender, Cancel
         {
             await Task.Delay(500, token);
             var bodyList = Enumerable.Range(1, 1).Select(x => new SimpleObj { Name = $"test sending {x}" });
-            await batchSender.AddEvent(bodyList, "test_routing_key_subscription");
+            await batchSender.AddEvent(bodyList, "test_routing_key");
         }
         catch (Exception e)
         {

--- a/samples/RabbitMQCoreClient.ConsoleClient/SimpleObj.cs
+++ b/samples/RabbitMQCoreClient.ConsoleClient/SimpleObj.cs
@@ -1,6 +1,14 @@
-﻿namespace RabbitMQCoreClient.ConsoleClient;
+﻿using System.Text.Json.Serialization;
+
+namespace RabbitMQCoreClient.ConsoleClient;
+
 
 public class SimpleObj
 {
     public string Name { get; set; }
+}
+
+[JsonSerializable(typeof(SimpleObj))]
+public partial class SimpleObjContext : JsonSerializerContext
+{
 }

--- a/src/RabbitMQCoreClient/BatchQueueSender/QueueEventsWriter.cs
+++ b/src/RabbitMQCoreClient/BatchQueueSender/QueueEventsWriter.cs
@@ -38,7 +38,7 @@ namespace RabbitMQCoreClient.BatchQueueSender
 
             try
             {
-                await _queueService.SendBatchAsync(items, routingKey, new System.Text.Json.JsonSerializerOptions());
+                await _queueService.SendBatchAsync(items, routingKey);
             }
             catch (Exception e)
             {

--- a/src/RabbitMQCoreClient/Extentions/SystemTextJsonQueueServiceExtentions.cs
+++ b/src/RabbitMQCoreClient/Extentions/SystemTextJsonQueueServiceExtentions.cs
@@ -1,21 +1,17 @@
-﻿using System;
+﻿using RabbitMQCoreClient.Serializers;
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Text.Json;
+#if NET6_0_OR_GREATER
+using System.Text.Json.Serialization.Metadata;
+#endif
 using System.Threading.Tasks;
 
 namespace RabbitMQCoreClient
 {
     public static class SystemTextJsonQueueServiceExtentions
     {
-        [NotNull]
-        public static JsonSerializerOptions DefaultSerializerSettings =>
-            new JsonSerializerOptions
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                DictionaryKeyPolicy = JsonNamingPolicy.CamelCase
-            };
-
         /// <summary>
         /// Send the message to the queue (thread safe method). <paramref name="obj" /> will be serialized to Json.
         /// </summary>
@@ -46,7 +42,7 @@ namespace RabbitMQCoreClient
             if (EqualityComparer<T>.Default.Equals(obj, default))
                 throw new ArgumentNullException(nameof(obj));
 
-            var serializedObj = JsonSerializer.Serialize(obj, jsonSerializerSettings ?? DefaultSerializerSettings);
+            var serializedObj = JsonSerializer.SerializeToUtf8Bytes(obj, jsonSerializerSettings ?? SystemTextJsonMessageSerializer.DefaultOptions);
             return queueService.SendJsonAsync(
                         serializedObj,
                         exchange: exchange,
@@ -56,8 +52,50 @@ namespace RabbitMQCoreClient
                        );
         }
 
+#if NET6_0_OR_GREATER
         /// <summary>
-        /// Send messages pack to the queue (thred safe method). <paramref name="objs" /> will be serialized to Json.
+        /// Send the message to the queue (thread safe method). <paramref name="obj" /> will be serialized to Json with source generator.
+        /// </summary>
+        /// <typeparam name="T">The class type of the message.</typeparam>
+        /// <param name="queueService">The <see cref="IQueueService"/> service object.</param>
+        /// <param name="obj">An instance of the <typeparamref name="T" /> class that will be serialized to JSON and sent to the queue.</param>
+        /// <param name="routingKey">The routing key with which the message will be sent.</param>
+        /// <param name="exchange">The name of the exchange point to which the message is to be sent.</param>
+        /// <param name="decreaseTtl">if set to <c>true</c> [decrease TTL].</param>
+        /// <param name="correlationId">Correlation Id, which is used to log messages.</param>
+        /// <param name="jsonTypeInfo">Metadata about the type to convert.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException">jsonString - jsonString
+        /// or
+        /// exchange - exchange</exception>
+        /// <exception cref="ArgumentNullException">obj</exception>
+        public static ValueTask SendAsync<T>(
+            this IQueueService queueService,
+            T obj,
+            string routingKey,
+            JsonTypeInfo<T> jsonTypeInfo,
+            string? exchange = default,
+            bool decreaseTtl = true,
+            string? correlationId = default
+            )
+        {
+            // Checking for Null without boxing. // https://stackoverflow.com/a/864860
+            if (EqualityComparer<T>.Default.Equals(obj, default))
+                throw new ArgumentNullException(nameof(obj));
+
+            var serializedObj = JsonSerializer.SerializeToUtf8Bytes(obj, jsonTypeInfo);
+            return queueService.SendJsonAsync(
+                        serializedObj,
+                        exchange: exchange,
+                        routingKey: routingKey,
+                        decreaseTtl: decreaseTtl,
+                        correlationId: correlationId
+                       );
+        }
+#endif
+
+        /// <summary>
+        /// Send pack of messages to the queue (thread safe method). <paramref name="objs" /> will be serialized to Json.
         /// </summary>
         /// <typeparam name="T">The class type of the message.</typeparam>
         /// <param name="queueService">The <see cref="IQueueService"/> service object.</param>
@@ -82,11 +120,11 @@ namespace RabbitMQCoreClient
             bool decreaseTtl = true,
             string? correlationId = default)
         {
-            var messages = new List<string>();
-            var serializeSettings = jsonSerializerSettings ?? DefaultSerializerSettings;
+            var messages = new List<ReadOnlyMemory<byte>>();
+            var serializeSettings = jsonSerializerSettings ?? SystemTextJsonMessageSerializer.DefaultOptions;
             foreach (var obj in objs)
             {
-                messages.Add(JsonSerializer.Serialize(obj, serializeSettings));
+                messages.Add(JsonSerializer.SerializeToUtf8Bytes(obj, serializeSettings));
             }
 
             return queueService.SendJsonBatchAsync(
@@ -97,5 +135,48 @@ namespace RabbitMQCoreClient
                 correlationId: correlationId
             );
         }
+
+#if NET6_0_OR_GREATER
+        /// <summary>
+        /// Send pack of messages to the queue (thread safe method). <paramref name="objs" /> will be serialized to Json with source generator.
+        /// </summary>
+        /// <typeparam name="T">The class type of the message.</typeparam>
+        /// <param name="queueService">The <see cref="IQueueService"/> service object.</param>
+        /// <param name="objs">A list of objects that are instances of the class <typeparamref name="T" /> 
+        /// that will be serialized to JSON and sent to the queue.</param>
+        /// <param name="routingKey">The routing key with which the message will be sent.</param>
+        /// <param name="exchange">The name of the exchange point to which the message is to be sent.</param>
+        /// <param name="decreaseTtl">If set to <c>true</c> [decrease TTL].</param>
+        /// <param name="correlationId">Correlation Id, which is used to log messages.</param>
+        /// <param name="jsonTypeInfo">Metadata about the type to convert.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException">jsonString - jsonString
+        /// or
+        /// exchange - exchange</exception>
+        /// <exception cref="ArgumentNullException">obj</exception>
+        public static ValueTask SendBatchAsync<T>(
+            this IQueueService queueService,
+            IEnumerable<T> objs,
+            string routingKey,
+            JsonTypeInfo<T> jsonTypeInfo,
+            string? exchange = default,
+            bool decreaseTtl = true,
+            string? correlationId = default)
+        {
+            var messages = new List<ReadOnlyMemory<byte>>();
+            foreach (var obj in objs)
+            {
+                messages.Add(JsonSerializer.SerializeToUtf8Bytes(obj, jsonTypeInfo));
+            }
+
+            return queueService.SendJsonBatchAsync(
+                serializedJsonList: messages,
+                exchange: exchange,
+                routingKey: routingKey,
+                decreaseTtl: decreaseTtl,
+                correlationId: correlationId
+            );
+        }
+#endif
     }
 }

--- a/src/RabbitMQCoreClient/IQueueService.cs
+++ b/src/RabbitMQCoreClient/IQueueService.cs
@@ -197,5 +197,24 @@ namespace RabbitMQCoreClient
             string? exchange = default,
             bool decreaseTtl = true,
             string? correlationId = default);
+
+        /// <summary>
+        /// Send batch messages to the queue (thread safe method).
+        /// </summary>
+        /// <param name="serializedJsonList">A list of serialized json to be sent to the queue in batch.</param>
+        /// <param name="routingKey">The routing key with which the message will be sent.</param>
+        /// <param name="exchange">The name of the exchange point to which the message is to be sent.</param>
+        /// <param name="decreaseTtl">If <c>true</c> then decrease TTL.</param>
+        /// <param name="correlationId">Correlation Id, which is used to log messages.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException">jsonString - jsonString
+        /// or
+        /// exchange - exchange</exception>
+        ValueTask SendJsonBatchAsync(
+            IEnumerable<ReadOnlyMemory<byte>> serializedJsonList,
+            string routingKey,
+            string? exchange = default,
+            bool decreaseTtl = true,
+            string? correlationId = default);
     }
 }

--- a/src/RabbitMQCoreClient/RabbitMQCoreClient.csproj
+++ b/src/RabbitMQCoreClient/RabbitMQCoreClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>6.0.1</Version>
+    <Version>6.0.2</Version>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(Version)-$(VersionSuffix)</Version>
     <IsPackable>true</IsPackable>

--- a/src/RabbitMQCoreClient/Serializers/SystemTextJsonMessageSerializer.cs
+++ b/src/RabbitMQCoreClient/Serializers/SystemTextJsonMessageSerializer.cs
@@ -6,21 +6,29 @@ namespace RabbitMQCoreClient.Serializers
 {
     public class SystemTextJsonMessageSerializer : IMessageSerializer
     {
+        static readonly System.Text.Json.JsonSerializerOptions _defaultOptions = new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            DictionaryKeyPolicy = System.Text.Json.JsonNamingPolicy.CamelCase
+        };
+
+        public static System.Text.Json.JsonSerializerOptions DefaultOptions => _defaultOptions;
+
+        static SystemTextJsonMessageSerializer()
+        {
+            _defaultOptions.Converters.Add(new JsonStringEnumConverter());
+            _defaultOptions.Converters.Add(new NewtonsoftJObjectConverter());
+            _defaultOptions.Converters.Add(new NewtonsoftJArrayConverter());
+            _defaultOptions.Converters.Add(new NewtonsoftJTokenConverter());
+        }
+
         public System.Text.Json.JsonSerializerOptions Options { get; }
 
         public SystemTextJsonMessageSerializer(Action<System.Text.Json.JsonSerializerOptions>? setupAction = null)
         {
             if (setupAction is null)
             {
-                Options = new System.Text.Json.JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true,
-                    DictionaryKeyPolicy = System.Text.Json.JsonNamingPolicy.CamelCase
-                };
-                Options.Converters.Add(new JsonStringEnumConverter());
-                Options.Converters.Add(new NewtonsoftJObjectConverter());
-                Options.Converters.Add(new NewtonsoftJArrayConverter());
-                Options.Converters.Add(new NewtonsoftJTokenConverter());
+                Options = _defaultOptions;
             }
             else
             {


### PR DESCRIPTION
Added extension methods to send messages with System.Text.Json serialized by source generator

- The Default System.Text.Json serializer options are now static and doesn't create on every serialization.
- Added forgotten method to to the IQueueService interface.